### PR TITLE
장바구니 화면 구현

### DIFF
--- a/src/main/java/edu/kh/laf/mypage/model/service/MypageLikeServiceImpl.java
+++ b/src/main/java/edu/kh/laf/mypage/model/service/MypageLikeServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import edu.kh.laf.mypage.model.mapper.MypageLikeMapper;
 
@@ -15,12 +16,14 @@ public class MypageLikeServiceImpl implements MypageLikeServcie {
 
 	// 찜 목록 추가
 	@Override
+	@Transactional(rollbackFor = Exception.class)
 	public int insertLike(Map<String, Object> map) {
 		return mapper.insertLike(map);
 	}
 
 	// 찜 목록 삭제
 	@Override
+	@Transactional(rollbackFor = Exception.class)
 	public int deleteLike(Map<String, Object> map) {
 		return mapper.deleteLike(map);
 	}

--- a/src/main/java/edu/kh/laf/product/controller/CartController.java
+++ b/src/main/java/edu/kh/laf/product/controller/CartController.java
@@ -138,7 +138,7 @@ public class CartController {
 		return 1;
 	}
 	
-	// [회원] 장바구니 상품 삭제
+	// [회원] 장바구니 상품 선택 삭제
 	@GetMapping("/cart/delete")
 	@ResponseBody
 	public int deleteCart(String data, @SessionAttribute("loginMember") Member loginMember)
@@ -146,10 +146,19 @@ public class CartController {
 		return cartService.deleteCart(data, loginMember.getMemberNo());
 	}
 	
-	// [비회원] 장바구니 상품 전체 삭제
-	@GetMapping("/cart/delete2All")
+	// [회원] 장바구니 상품 전체 삭제
+	@GetMapping("/cart/deleteAll")
 	@ResponseBody
-	public int deleteCart2All(HttpServletResponse resp) {
+	public int deleteCartAll(@SessionAttribute("loginMember") Member loginMember)
+			throws JsonProcessingException {
+		return cartService.deleteCartAll(loginMember.getMemberNo());
+	}
+
+	
+	// [비회원] 장바구니 상품 전체 삭제
+	@GetMapping("/cart/deleteAll2")
+	@ResponseBody
+	public int deleteCartAll2(HttpServletResponse resp) {
 		Cookie cookie = new Cookie("cart", "");
 		cookie.setMaxAge(1);
 		cookie.setPath("/");
@@ -169,6 +178,29 @@ public class CartController {
 		Cookie cookie = cartService.deleteCart2(cookies, data);
 		resp.addCookie(cookie);
 		
+		return 1;
+	}
+	
+	// [회원] 장바구니 상품 수정
+	@GetMapping("/cart/update")
+	@ResponseBody
+	public int updateCart(
+			String data, 
+			@SessionAttribute("loginMember") Member loginMember
+		) throws JsonProcessingException {
+		return cartService.deleteCartAll(loginMember.getMemberNo())
+				* cartService.insertCart(data, loginMember.getMemberNo());
+	}
+	
+	// [비회원] 장바구니 상품 수정
+	@GetMapping("/cart/update2")
+	@ResponseBody
+	public int updateCart2(
+			String data,
+			HttpServletResponse resp) {
+		Cookie cookie = cartService.insertCart2(null, data);
+		if(cookie == null) return -1;
+		resp.addCookie(cookie);
 		return 1;
 	}
 	

--- a/src/main/java/edu/kh/laf/product/model/dto/Cart.java
+++ b/src/main/java/edu/kh/laf/product/model/dto/Cart.java
@@ -1,8 +1,14 @@
 package edu.kh.laf.product.model.dto;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
-@Data
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
 public class Cart {
 	private long productNo;
 	private long memberNo;

--- a/src/main/java/edu/kh/laf/product/model/mapper/CartMapper.java
+++ b/src/main/java/edu/kh/laf/product/model/mapper/CartMapper.java
@@ -25,10 +25,17 @@ public interface CartMapper {
 	List<Cart> selectCart(long memberNo);
 
 	/**
-	 * 장바구니 상품 삭제
+	 * 장바구니 상품 선택 삭제
 	 * @param cartList
 	 * @return result
 	 */
 	int deleteCart(List<Cart> cartList);
+
+	/**
+	 * 장바구니 상품 전체 삭제
+	 * @param memberNo
+	 * @return result
+	 */
+	int deleteCartAll(Long memberNo);
 
 }

--- a/src/main/java/edu/kh/laf/product/model/service/CartService.java
+++ b/src/main/java/edu/kh/laf/product/model/service/CartService.java
@@ -4,26 +4,43 @@ import java.util.List;
 
 import edu.kh.laf.order.model.dto.OrderProduct;
 import edu.kh.laf.product.model.dto.Cart;
+import jakarta.servlet.http.Cookie;
 
 public interface CartService {
 
 	/**
-	 * 장바구니 상품 목록 조회
+	 * [회원] 장바구니 상품 목록 조회
 	 * @param memberNo
 	 * @return cartList
 	 */
 	List<Cart> selectCart(Long memberNo);
+	
+	/**
+	 * [비회원] 장바구니 상품 목록 조회
+	 * @param cartCookie
+	 * @return cartList
+	 */
+	List<Cart> selectCart(Cookie cartCookie);
 
 	/**
-	 * 장바구니에 상품 추가
+	 * [회원] 장바구니에 상품 추가
 	 * @param cartList
 	 * @param memberNo
 	 * @return result
 	 */
 	int insertCart(String data, Long memberNo);
 
+
 	/**
-	 * 장바구니 상품 삭제
+	 * [비회원] 장바구니에 상품 추가
+	 * @param cookies
+	 * @param data
+	 * @return cookie
+	 */
+	Cookie insertCart2(Cookie[] cookies, String data);
+	
+	/**
+	 * [회원] 장바구니 상품 삭제
 	 * @param data
 	 * @param memberNo
 	 * @return result
@@ -31,10 +48,23 @@ public interface CartService {
 	int deleteCart(String data, Long memberNo);
 	
 	/**
+	 * [비회원] 장바구니 상품 선택 삭제
+	 * @param cookies
+	 * @param data
+	 * @return cookie
+	 */
+	Cookie deleteCart2(Cookie[] cookies, String data);
+
+	/**
 	 * 결제완료 후 장바구니 상품 삭제
 	 * @param orderList
 	 * @return result
 	 */
 	int deleteCartAfterOrder(List<OrderProduct> orderList);
+
+
+
+	
+
 
 }

--- a/src/main/java/edu/kh/laf/product/model/service/CartService.java
+++ b/src/main/java/edu/kh/laf/product/model/service/CartService.java
@@ -40,7 +40,14 @@ public interface CartService {
 	Cookie insertCart2(Cookie[] cookies, String data);
 	
 	/**
-	 * [회원] 장바구니 상품 삭제
+	 * [회원] 장바구니 상품 전체 삭제
+	 * @param memberNo
+	 * @return result
+	 */
+	int deleteCartAll(Long memberNo);
+
+	/**
+	 * [회원] 장바구니 상품 선택 삭제
 	 * @param data
 	 * @param memberNo
 	 * @return result
@@ -61,6 +68,7 @@ public interface CartService {
 	 * @return result
 	 */
 	int deleteCartAfterOrder(List<OrderProduct> orderList);
+
 
 
 

--- a/src/main/java/edu/kh/laf/product/model/service/CartServiceImpl.java
+++ b/src/main/java/edu/kh/laf/product/model/service/CartServiceImpl.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.json.BasicJsonParser;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import edu.kh.laf.order.model.dto.OrderProduct;
 import edu.kh.laf.product.model.dto.Cart;
@@ -40,6 +41,7 @@ public class CartServiceImpl implements CartService {
 
 	// [회원] 장바구니에 상품 추가
 	@Override
+	@Transactional(rollbackFor = Exception.class)
 	public int insertCart(String data, Long memberNo) {
 		
 		// 배열 형태 JSON data parsing
@@ -67,9 +69,11 @@ public class CartServiceImpl implements CartService {
 		
 		// 이전 장바구니 정보 찾기
 		Cookie cart = null;
-		for(Cookie c : cookies) {
-			if(c.getName().equals("cart")) {
-				cart = c;
+		if(cookies != null) {
+			for(Cookie c : cookies) {
+				if(c.getName().equals("cart")) {
+					cart = c;
+				}
 			}
 		}
 
@@ -97,6 +101,7 @@ public class CartServiceImpl implements CartService {
 
 	// [회원] 장바구니 상품 삭제
 	@Override
+	@Transactional(rollbackFor = Exception.class)
 	public int deleteCart(String data, Long memberNo) {
 		
 		// 배열 형태 JSON data parsing
@@ -117,8 +122,9 @@ public class CartServiceImpl implements CartService {
 		return mapper.deleteCart(cartList);
 	}
 
-	// 주문완료 후 장바구니 삭제
+	// [회원] 주문완료 후 장바구니 삭제
 	@Override
+	@Transactional(rollbackFor = Exception.class)
 	public int deleteCartAfterOrder(List<OrderProduct> orderList) {
 		
 		// Cart 타입 리스트에 담기
@@ -175,6 +181,12 @@ public class CartServiceImpl implements CartService {
 		cookie.setPath("/");
 		
 		return cookie;
+	}
+
+	// [회원] 장바구니 상품 전체 삭제
+	@Override
+	public int deleteCartAll(Long memberNo) {
+		return mapper.deleteCartAll(memberNo);
 	}
 	
 }

--- a/src/main/java/edu/kh/laf/product/model/service/CartServiceImpl.java
+++ b/src/main/java/edu/kh/laf/product/model/service/CartServiceImpl.java
@@ -1,6 +1,7 @@
 package edu.kh.laf.product.model.service;
 
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Service;
 import edu.kh.laf.order.model.dto.OrderProduct;
 import edu.kh.laf.product.model.dto.Cart;
 import edu.kh.laf.product.model.mapper.CartMapper;
+import jakarta.servlet.http.Cookie;
 
 @Service
 public class CartServiceImpl implements CartService {
@@ -18,13 +20,25 @@ public class CartServiceImpl implements CartService {
 	@Autowired
 	private CartMapper mapper;
 
-	// 장바구니 상품 목록 조회
+	// [회원] 장바구니 상품 목록 조회
 	@Override
 	public List<Cart> selectCart(Long memberNo) {
 		return mapper.selectCart(memberNo);
 	}
+	
+	// [비회원] 장바구니 상품 목록 조회
+	@Override
+	public List<Cart> selectCart(Cookie cartCookie) {
+		
+		List<Cart> cartList = new ArrayList<>(); 
+		
+		cartCookie.getAttribute("productNo");
+		cartCookie.getAttribute("optionNo");
+		
+		return cartList;
+	}
 
-	// 장바구니에 상품 추가
+	// [회원] 장바구니에 상품 추가
 	@Override
 	public int insertCart(String data, Long memberNo) {
 		
@@ -46,8 +60,42 @@ public class CartServiceImpl implements CartService {
 		
 		return mapper.insertCart(cartList);
 	}
+	
+	// [비회원] 장바구니에 상품 추가
+	@Override
+	public Cookie insertCart2(Cookie[] cookies, String data) {
+		
+		// 이전 장바구니 정보 찾기
+		Cookie cart = null;
+		for(Cookie c : cookies) {
+			if(c.getName().equals("cart")) {
+				cart = c;
+			}
+		}
 
-	// 장바구니 상품 삭제
+		// 쿠키 데이터 생성 : 장바구니 + 신규 데이터
+		String newData = cart == null ? data : cart.getValue() + data;
+		Cookie cookie = new Cookie("cart", newData);
+		
+		// 오늘 자정에 쿠키 만료
+		Calendar tomorrow = Calendar.getInstance();
+		long now = tomorrow.getTimeInMillis();		
+		tomorrow.add(Calendar.DATE, 1);
+		tomorrow.set(Calendar.HOUR, 0);
+		tomorrow.set(Calendar.MINUTE, 0);
+		tomorrow.set(Calendar.SECOND, -1);
+		long tomo = tomorrow.getTimeInMillis();
+		int sec = (int) ((tomo - now) / 1000);
+		cookie.setMaxAge(sec);
+		
+		// 기타 정보 지정
+		cookie.setPath("/");
+		
+		return cookie;
+	}
+	
+
+	// [회원] 장바구니 상품 삭제
 	@Override
 	public int deleteCart(String data, Long memberNo) {
 		
@@ -84,6 +132,49 @@ public class CartServiceImpl implements CartService {
 		}
 		
 		return mapper.deleteCart(cartList);
+	}
+
+	// [비회원] 장바구니 상품 선택 삭제
+	@Override
+	public Cookie deleteCart2(Cookie[] cookies, String data) {
+		
+		// 이전 장바구니 정보 찾기
+		Cookie cart = null;
+		for(Cookie c : cookies) {
+			if(c.getName().equals("cart")) {
+				cart = c;
+			}
+		}
+		
+		String newData = cart.getValue();
+		String[] arr = data.split("@");
+		for(int i=0; i<arr.length; i++) {
+			newData = newData.replace(arr[i] + "@", "");
+		}
+		
+		// 쿠키 데이터 생성
+		Cookie cookie = new Cookie("cart", newData);
+
+		if(newData.trim().length() == 0) {
+			cookie.setMaxAge(0);
+		} else {
+
+			// 오늘 자정에 쿠키 만료
+			Calendar tomorrow = Calendar.getInstance();
+			long now = tomorrow.getTimeInMillis();		
+			tomorrow.add(Calendar.DATE, 1);
+			tomorrow.set(Calendar.HOUR, 0);
+			tomorrow.set(Calendar.MINUTE, 0);
+			tomorrow.set(Calendar.SECOND, -1);
+			long tomo = tomorrow.getTimeInMillis();
+			int sec = (int) ((tomo - now) / 1000);
+			cookie.setMaxAge(sec);
+		}
+		
+		// 기타 정보 지정
+		cookie.setPath("/");
+		
+		return cookie;
 	}
 	
 }

--- a/src/main/resources/mappers/cart-mapper.xml
+++ b/src/main/resources/mappers/cart-mapper.xml
@@ -16,7 +16,7 @@
 			</foreach>
 	</insert>
 	
-	<!-- 장바구니에 상품 삭제 -->
+	<!-- 장바구니에 상품 선택 삭제 -->
 	<delete id="deleteCart" parameterType="list">
 		delete from `cart`
 		<where>
@@ -28,6 +28,12 @@
 			)
 			</foreach>
 		</where>
+	</delete>
+	
+	<!-- 장바구니에 상품 전체 삭제 -->
+	<delete id="deleteCartAll" parameterType="long">
+		delete from `cart`
+		where member_no = ${memberNo}
 	</delete>
 	
 	<!-- 유저 번호로 장바구니 목록 조회 -->

--- a/src/main/resources/static/css/shopping/cart.css
+++ b/src/main/resources/static/css/shopping/cart.css
@@ -87,15 +87,13 @@ tr:not(:first-child) > .cart-item-product {
 #cartItemList .cart-item-count button {
   width: 20px;
   height: 20px;
-  margin: 0 10px;
+  /* margin: 0 10px; */
 }
-/* #cartItemList > .btn-container > button {
-  height: 40px;
-  width: 120px;
-  border-radius: 2px;
-} */
-
-
+.cart-item-count > span {
+  /* 주문수량 출력부 */
+  text-align: center;
+  width: 40px;  
+}
 
 /* 결제예상금액 */
 #cartPrice {

--- a/src/main/resources/static/css/shopping/cart.css
+++ b/src/main/resources/static/css/shopping/cart.css
@@ -113,7 +113,7 @@ tr:not(:first-child) > .cart-item-product {
   margin: 0 5px;
 }
 
-#cartPrice .cart-price-total-payment .data {
+#cartPrice > table tr.table-data > .cart-price-total-payment {
   font-size: 2rem;
   font-weight: bold;
   color: #D66600;

--- a/src/main/resources/static/js/common/common.js
+++ b/src/main/resources/static/js/common/common.js
@@ -15,10 +15,3 @@ function getCookie(key) {
 
   return obj[key];
 }
-
-// 쿠키에 저장된 장바구니 정보 얻어오기
-function getCart() {
-  const cart = getCookie('cart');
-  if(!cart) return null;
-  return JSON.parse(cart);
-}

--- a/src/main/resources/static/js/shopping/cart.js
+++ b/src/main/resources/static/js/shopping/cart.js
@@ -142,11 +142,18 @@ clearCartBtn.addEventListener('click', () => {
 // 선택한 상품만 삭제
 const deleteSelectedBtn = document.getElementById('deleteSelectedBtn');
 deleteSelectedBtn.addEventListener('click', () => {
-  if(!confirm("해당 상품을 정말로 삭제하시겠습니까?")) return;
-
+  
   const data = getSelectedData();
+  if(data.length == 0) {
+    alert('선택한 상품이 없습니다.');
+    return;
+  }
+
+  if(!confirm("해당 상품을 정말로 삭제하시겠습니까?")) return;
+  
   let url = "/cart/delete?data=" + encodeURIComponent(JSON.stringify(data));
   
+  // 비회원인 경우
   if(loginMember == undefined) {
     url = "/cart/delete2?data=";
     for(let d of data) {
@@ -154,8 +161,6 @@ deleteSelectedBtn.addEventListener('click', () => {
     }
   }
   
-  console.log(url);
-
   fetch(url)
   .then(resp => resp.text())
   .then(result => {
@@ -193,10 +198,30 @@ deleteSelectedBtn.addEventListener('click', () => {
 
 // 선택상품주문
 const orderSelectedBtn = document.getElementById('orderSelectedBtn');
-orderSelectedBtn.addEventListener('click', () => {
-  if(data.length == 0) {
-    alert('선택된 상품이 없습니다.');
-    return ;
+orderSelectedBtn.addEventListener('click', e => {
+  e.preventDefault();
+
+  const rowList = document.querySelectorAll('.data-tr');
+  let flag = true; // 아무것도 체크 안했을 때 확인
+  for(let row of rowList) {
+    const checkbox = row.querySelector('[name="checkbox"]');
+    const productNoInput = row.querySelector('input[name="productNo"]');
+    const optionNoInput = row.querySelector('input[name="optionNo"]');
+    const countInput = row.querySelector('input[name="count"]');
+
+    if(checkbox.checked == false) {
+      productNoInput.disabled = true;
+      optionNoInput.disabled = true;
+      countInput.disabled = true;
+    } else {
+      flag = false;
+    }
   }
-  alert('선택상품주문');
+
+  if(flag) {
+    alert('선택한 상품이 없습니다.');
+    return;
+  }
+  
+  document.getElementById('cartFrm').submit();
 });

--- a/src/main/resources/static/js/shopping/cart.js
+++ b/src/main/resources/static/js/shopping/cart.js
@@ -145,7 +145,7 @@ clearCartBtn.addEventListener('click', () => {
 
   // [비회원]
   if(loginMember == undefined) {
-    url = "/cart/delete2All"
+    url = "/cart/deleteAll2"
   }
 
   fetch(url)
@@ -266,3 +266,51 @@ orderSelectedBtn.addEventListener('click', e => {
   document.getElementById('cartFrm').submit();
 });
 
+// 장바구니 상품 수량 변경
+const countBtns = document.querySelectorAll('.cart-item-count > button');
+for(let btn of countBtns) {
+  btn.addEventListener('click', e => {
+    const countText = e.target.parentElement.querySelector('span');
+    const countInput = e.target.parentElement.parentElement.querySelector('input[name="count"]');
+
+    let count = Number(countInput.value);
+    if(btn.classList.contains('minus-btn')) count--;
+    else count++;
+
+    if(count <= 0) {
+      alert('최소 주문 수량은 1개 입니다.');
+      count = 1;
+    } else if(count >= 100) {
+      alert('최대 주문 수량은 99개 입니다.');
+      count = 99;
+    }
+
+    countText.innerText = count;
+    countInput.value = count;
+
+    const data = getAllData();
+    let url = "";
+
+    if(loginMember != undefined) {
+      // 회원 : update DB
+      const dataStr = encodeURIComponent(JSON.stringify(data));
+      url = "/cart/update?data=" + dataStr;
+      console.log("dataStr : " + dataStr);
+    } else {
+      // 비회원 : update cookie
+      let cookieStr = "";
+      for(let d of data)
+        cookieStr += d.productNo + '-' + d.optionNo + '-' + d.count + '@';
+      url = "/cart/update2?data=" + cookieStr;
+    }
+
+    fetch(url)
+    .then(resp => resp.text())
+    .then(result => {
+      if(result <= 0) alert("수량 변경 실패");
+    }) 
+    .catch(err => console.log(err));
+
+    estimate();
+  });
+}

--- a/src/main/resources/static/js/shopping/cart.js
+++ b/src/main/resources/static/js/shopping/cart.js
@@ -1,3 +1,40 @@
+// 결제예상금액 계산
+function estimate() {
+  const totalOrigin = document.querySelector('.table-data > .cart-price-total-origin');
+  const shipping = document.querySelector('.table-data > .cart-price-shipping');
+  const totalDiscount = document.querySelector('.table-data > .cart-price-total-discount');
+  const totalPayment = document.querySelector('.table-data > .cart-price-total-payment');
+
+  let totalOriginCalc = 0;
+  let totalPaymentCalc = 0;
+
+  const rowList = document.querySelectorAll('.data-tr');
+  for(let row of rowList) {
+    const checkbox = row.querySelector('[name="checkbox"]');
+    const countInput = row.querySelector('input[name="count"]');
+
+    if(checkbox.checked == true) {
+      const pay = Number(row.querySelector('.cart-item-price').innerText.replaceAll(',', ''));
+      const origin = row.querySelector('.cart-item-price-origin') == null ? pay : Number(row.querySelector('.cart-item-price-origin').innerText.replaceAll(',', ''));
+      totalOriginCalc += origin * Number(countInput.value);
+      totalPaymentCalc += pay * Number(countInput.value);
+    }
+  }
+
+  const shippingCalc = totalPaymentCalc >= 100000 ? 0 : 3000;
+  totalOrigin.innerText = numberWithCommas(totalOriginCalc);
+  totalDiscount.innerText = '- ' + numberWithCommas(totalOriginCalc - totalPaymentCalc);
+  shipping.innerText = '+ ' + numberWithCommas(shippingCalc);
+  totalPayment.innerText = numberWithCommas(totalPaymentCalc + shippingCalc);
+}
+
+const checkboxList = document.querySelectorAll('[name="checkbox"]');
+for(let checkbox of checkboxList) {
+  checkbox.addEventListener('change', () => {
+    estimate();
+  });
+}
+
 // 전체선택 체크박스
 const checkboxSelectAll = document.getElementById('checkboxSelectAll');
 checkboxSelectAll.addEventListener('click', e => {
@@ -11,6 +48,9 @@ checkboxSelectAll.addEventListener('click', e => {
     ch.checked = false;
   }
 });
+
+// 장바구니 기본값 : 전체선택
+checkboxSelectAll.click();
 
 // 전체상품 데이터 추출
 const productInputList = document.querySelectorAll('input[name="productNo"]');
@@ -72,14 +112,14 @@ for(let btn of deleteBtns) {
         tr.remove();
 
         // 장바구니에 남은 상품이 하나도 없을 경우 비어있는 행 추가
-        if(tr.querySelector('.data-tr') == null) {
+        const table = document.querySelector('#cartItemList > table');
+        if(table.querySelector('.data-tr') == null) {
           const td = document.createElement('td');
           td.classList.add('cart-item-empty');
           td.colspan = 7;
           td.innerText = '장바구니가 비어 있습니다.';
           const tr = document.createElement('tr');
           tr.append(td);
-          const table = document.querySelector('#cartItemList > table');
           table.append(tr);
         }
 
@@ -225,3 +265,4 @@ orderSelectedBtn.addEventListener('click', e => {
   
   document.getElementById('cartFrm').submit();
 });
+

--- a/src/main/resources/templates/common/nav.html
+++ b/src/main/resources/templates/common/nav.html
@@ -46,7 +46,8 @@
   <div th:unless="${session.loginMember}" class="header-nav-icon">
     <a href="/1"><img src="/images/common/search.svg"></a>
     <a href="/login"><img src="/images/common/user.svg"></a>
-    <a href="/cart"><img src="/images/common/cart.svg"></a>
+    <a th:if="${session.loginMember}" th:href="@{/cart}"><img src="/images/common/cart.svg"></a>
+    <a th:unless="${session.loginMember}" th:href="@{/cart2}"><img src="/images/common/cart.svg"></a>
   </div>
 
   <div th:if="${session.loginMember}" class="header-nav-icon">

--- a/src/main/resources/templates/shopping/cart.html
+++ b/src/main/resources/templates/shopping/cart.html
@@ -103,10 +103,10 @@
             <td class="cart-price-total-payment">결제예정금액</td>
           </tr>
           <tr class="table-data">
-            <td class="cart-price-total-origin data">32,500</td>
-            <td class="cart-price-shipping">+<span class="data">3,000</span></td>
-            <td class="cart-price-total-discount">-<span class="data">0</span></td>
-            <td class="cart-price-total-payment"><span class="data">35,500</span></td>
+            <td class="cart-price-total-origin data">0</td>
+            <td class="cart-price-shipping">+ 3,000</td>
+            <td class="cart-price-total-discount">- 0</td>
+            <td class="cart-price-total-payment">0</td>
           </tr>
         </table>
 

--- a/src/main/resources/templates/shopping/cart.html
+++ b/src/main/resources/templates/shopping/cart.html
@@ -20,6 +20,7 @@
     </div>
 
     <!-- 장바구니 목록 -->
+    
     <form th:action="@{/cart/order}" method="POST">
       <section id="cartItemList">
         <table>
@@ -41,6 +42,7 @@
 
             <input type="hidden" name="productNo" th:value="${product.productNo}">
             <input type="hidden" name="optionNo" th:value="${optionList[productStat.index].optionNo}">
+            <input type="hidden" name="count" th:value="${cartList[productStat.index].count}">
             
             <td class="cart-item-checkbox">
               <input type="checkbox" name="checkbox" class="checkbox-item">

--- a/src/main/resources/templates/shopping/cart.html
+++ b/src/main/resources/templates/shopping/cart.html
@@ -64,9 +64,9 @@
             </td>
             
             <td class="cart-item-count">
-              <button type="button">-</button>
+              <button type="button" class="minus-btn">-</button>
               <span th:text="${cartList[productStat.index].count}">주문수량</span>
-              <button type="button">+</button>
+              <button type="button" class="plus-btn">+</button>
             </td>
             
             <td class="cart-item-price-set">

--- a/src/main/resources/templates/shopping/cart.html
+++ b/src/main/resources/templates/shopping/cart.html
@@ -21,7 +21,7 @@
 
     <!-- 장바구니 목록 -->
     
-    <form th:action="@{/cart/order}" method="POST">
+    <form th:action="@{/cart/order}" method="POST" id="cartFrm">
       <section id="cartItemList">
         <table>
           <tr>


### PR DESCRIPTION
- 결제정보 넘길 때 수량도 같이 넘기도록 수정
- 비회원 쿠키 생성 주체 변경(클라이언트 → 서버)
- 비회원 장바구니 조회
- 비회원 장바구니 삭제 (개별, 선택, 전체)
- 비회원 주문
- 회원, 비회원 선택상품 주문
- 버튼으로 상품 삭제시 '장바구니가 비어있습니다' 문구가 항상 출력되던 오류 수정
- 예상결제금액 실시간 계산 구현
- 장바구니 기본값으로 전체상품선택 상태로 변경
- @Transactional 어노테이션 추가
- 회원, 비회원 장바구니 상품 수량 변경 → 화면, DB, 쿠키 변경