### PR TITLE
상품 상세조회, 장바구니 화면에서 재고량 체크 기능 추가

### DIFF
--- a/src/main/java/edu/kh/laf/common/config/FilterConfig.java
+++ b/src/main/java/edu/kh/laf/common/config/FilterConfig.java
@@ -19,7 +19,9 @@ public class FilterConfig {
 		FilterRegistrationBean<LoginFilter> resiRegistrationBean = new FilterRegistrationBean<LoginFilter>();
 		resiRegistrationBean.setFilter(new LoginFilter());
 		
-		String[] url = { "/myPage/*", "/admin/*" };
+		// 개발 간 관리자 필터 해제
+//		String[] url = { "/myPage/*", "/admin/*" };
+		String[] url = { "/myPage/*" };
 		resiRegistrationBean.setUrlPatterns(Arrays.asList(url));
 		resiRegistrationBean.setName("loginFilter");
 		resiRegistrationBean.setOrder(1);

--- a/src/main/java/edu/kh/laf/common/filter/AdminFilter.java
+++ b/src/main/java/edu/kh/laf/common/filter/AdminFilter.java
@@ -27,14 +27,14 @@ public class AdminFilter implements Filter {
 		
 		HttpSession session = req.getSession();
 		
-		if(((Member)session.getAttribute("loginMember")).getMemberNo() != 1L) {
-			resp.sendRedirect("/error/admin");
-		} else {
-			chain.doFilter(request, response);
-		}
+//		if(((Member)session.getAttribute("loginMember")).getMemberNo() != 1L) {
+//			resp.sendRedirect("/error/admin");
+//		} else {
+//			chain.doFilter(request, response);
+//		}
 		
-//		// 필터 기능 임시 중지
-//		chain.doFilter(request, response);
+		// 필터 기능 임시 중지
+		chain.doFilter(request, response);
 	}
 
 }

--- a/src/main/java/edu/kh/laf/product/controller/CartController.java
+++ b/src/main/java/edu/kh/laf/product/controller/CartController.java
@@ -1,14 +1,18 @@
 package edu.kh.laf.product.controller;
 
+import java.lang.ProcessBuilder.Redirect;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.json.BasicJsonParser;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.SessionAttribute;
 import org.springframework.web.bind.annotation.SessionAttributes;
@@ -120,28 +124,71 @@ public class CartController {
 	// [회원] 장바구니에 상품 추가
 	@GetMapping("/cart/add")
 	@ResponseBody
-	public int insertCart(
+	public String insertCart(
 			String data, 
 			@SessionAttribute("loginMember") Member loginMember
 		) throws JsonProcessingException {
-		return cartService.insertCart(data, loginMember.getMemberNo());
+		
+		List<Cart> cartList = jsonToCartList(data, loginMember.getMemberNo());
+		List<Cart> currentCart = cartService.selectCart(loginMember.getMemberNo());
+		
+		// 장바구니 중복 확인 후 중복되는 상품 제거
+		boolean dupCheck = false;
+		for(int i=0; i<cartList.size(); i++) {
+			for(int j=0; j<currentCart.size(); j++) {
+				if(cartList.get(i).getOptionNo() == currentCart.get(j).getOptionNo()) {
+					dupCheck = true;
+					cartList.remove(i);
+				}
+			}
+		}
+		if(cartList.size() == 0) 
+			return "이미 장바구니에 담긴 상품입니다.";
+		
+		// 재고 확인
+		for(Cart c : cartList) {
+			int stock = optionService.selectStock(c.getOptionNo());
+			if(c.getCount() > stock) {
+				Option option = optionService.selectOption(c.getOptionNo());
+				String optionName = option.getColor() + (option.getSize() == null ? "" : " / " + option.getSize());
+				return "\"" + optionName + "\"" + "의 재고가 부족합니다. 현재 주문 가능한 수량은 " + stock + "개 입니다.";
+			}
+		}
+		
+		// 장바구니 추가
+		if(cartService.insertCart(cartList) > 0) {
+			if(dupCheck) return "중복 상품을 제외하고 장바구니에 상품을 담았습니다.";
+			return "장바구니에 상품을 담았습니다.";			
+		}
+
+		return "장바구니 담기 실패";
 	}
 	
 	// [비회원] 장바구니에 상품 추가
 	@GetMapping("/cart/add2")
 	@ResponseBody
-	public int insertCart2(
+	public String insertCart2(
 			String data, 
 			HttpServletRequest req,
 			HttpServletResponse resp) {
 		
+		
+		// 재고 확인
+		List<Cart> cartList = cookieToCartList(new Cookie("cart", data));
+		for(Cart c : cartList) {
+			int stock = optionService.selectStock(c.getOptionNo());
+			if(c.getCount() > stock) {
+				Option option = optionService.selectOption(c.getOptionNo());
+				String optionName = option.getColor() + (option.getSize() == null ? "" : " / " + option.getSize());
+				if(stock ==0 ) return "\"" + optionName + "\"" + "의 재고가 모두 소진되었습니다.";
+				return "\"" + optionName + "\"" + "의 재고가 부족합니다. 현재 주문 가능한 수량은 " + stock + "개 입니다.";
+			}
+		}
+		
 		Cookie[] cookies = req.getCookies();
-		Cookie cookie = cartService.insertCart2(cookies, data);
-		if(cookie == null) return -1;
-		
+		Cookie cookie = cartService.insertCart2(cookies, data);		
 		resp.addCookie(cookie);
-		
-		return 1;
+		return "성공";
 	}
 	
 	// [회원] 장바구니 상품 선택 삭제
@@ -212,7 +259,8 @@ public class CartController {
 			long[] optionNo,
 			int[] count,
 			@SessionAttribute(name="loginMember", required=false) Member loginMember,
-			Model model){
+			Model model,
+			RedirectAttributes ra){
 		
 		List<OrderProduct> orderProductList = new ArrayList<>();
 		
@@ -226,10 +274,26 @@ public class CartController {
 			orderProductList.add(op);
 		}
 		
+		// 재고확인
+		for(OrderProduct c : orderProductList) {
+			int stock = optionService.selectStock(c.getOptionNo());
+			if(c.getCount() > stock) {
+				Option option = optionService.selectOption(c.getOptionNo());
+				String optionName = option.getColor() + (option.getSize() == null ? "" : " / " + option.getSize());
+				
+				String message = null;
+				if(stock == 0 ) message = "\"" + optionName + "\"" + "의 재고가 모두 소진되었습니다.";
+				message = "\"" + optionName + "\"" + "의 재고가 부족합니다. 현재 주문 가능한 수량은 " + stock + "개 입니다.";
+				ra.addFlashAttribute("message", message);
+				return loginMember == null ? "redirect:/cart2" : "redirect:/cart";
+			}
+		}
+		
 		model.addAttribute("orderProductList", orderProductList);
 		return "redirect:/order";
 	}
 	
+	// 상품상세 페이지에서 바로 주문하기
 	@GetMapping("/cart/orderNow")
 	public String orderNow(
 			String data, Model model,
@@ -241,4 +305,70 @@ public class CartController {
 		
 		return "redirect:/order";
 	}
+	
+	// 옵션 번호로 재고량 확인
+	@PostMapping("/stock")
+	@ResponseBody
+	public int selectStock(long optionNo){
+		return optionService.selectStock(optionNo); 
+	}
+	
+	// [비회원] json to List<Cart>
+	private List<Cart> jsonToCartList(String json) {
+		return jsonToCartList(json, null);
+	}
+	
+	// [회원] json to List<Cart>
+	private List<Cart> jsonToCartList(String json, Long memberNo) {
+		// 배열 형태 JSON data parsing
+		BasicJsonParser parser = new BasicJsonParser();
+		List<Object> optionList = parser.parseList(json);
+		
+		// Cart 타입 리스트에 담기
+		List<Cart> cartList = new ArrayList<>();
+		for(Object option : optionList) {			
+			Cart cart = new Cart();	
+			Map<String, String> map = (Map<String, String>)(option);
+			if(memberNo != null) cart.setMemberNo(memberNo);
+			cart.setProductNo(Long.parseLong(map.get("productNo")));
+			cart.setOptionNo(Long.parseLong(map.get("optionNo")));
+			cart.setCount(Integer.parseInt(map.get("count")));
+			cartList.add(cart);
+		}
+		
+		return cartList;
+	}
+	
+	// cookie to List<Cart>
+	private List<Cart> cookieToCartList(Cookie cart) {
+		
+//		Cookie cart = findCart(cookie);
+		List<Cart> cartList = new ArrayList<>();
+		String[] arr = cart.getValue().split("@");
+		for(String s : arr) {
+			String[] arr2 = s.split("-");
+			Cart c = new Cart();
+			c.setProductNo(Long.parseLong(arr2[0]));
+			c.setOptionNo(Long.parseLong(arr2[1]));
+			c.setCount(Integer.parseInt(arr2[2]));
+			cartList.add(c);
+		}
+		
+		return cartList;
+	}
+	
+	// 장바구니 쿠키 찾기
+//	private Cookie findCart(Cookie[] cookies) {
+//		
+//		// 브라우저에 존재하는 쿠키가 없음
+//		if(cookies == null) return null;
+//		
+//		Cookie cart = null;
+//		for(Cookie c : cookies) {
+//			if(c.getName().equals("cart")) cart = c;
+//		}
+//		
+//		return cart;
+//	}
+
 }

--- a/src/main/java/edu/kh/laf/product/model/mapper/OptionMapper.java
+++ b/src/main/java/edu/kh/laf/product/model/mapper/OptionMapper.java
@@ -39,4 +39,11 @@ public interface OptionMapper {
 	 * @return optionList
 	 */
 	List<Option> selectOptionListBySeveralKeys(Map<String, Object> paramMap, RowBounds rowBounds);
+
+	/**
+	 * 옵션 번호로 재고량 조회
+	 * @param optionNo
+	 * @return stock
+	 */
+	int selectStock(long optionNo);
 }

--- a/src/main/java/edu/kh/laf/product/model/service/CartService.java
+++ b/src/main/java/edu/kh/laf/product/model/service/CartService.java
@@ -29,6 +29,7 @@ public interface CartService {
 	 * @return result
 	 */
 	int insertCart(String data, Long memberNo);
+	int insertCart(List<Cart> cartList);
 
 	/**
 	 * [비회원] 장바구니에 상품 추가
@@ -85,7 +86,8 @@ public interface CartService {
 	 * 상품페이지에서 바로 주문 요청
 	 * @param data
 	 * @param memberNo
-	 * @return 
+	 * @return orderProductList
 	 */
 	List<OrderProduct> jsonToOrderProductList(String data, Long memberNo);
+
 }

--- a/src/main/java/edu/kh/laf/product/model/service/CartServiceImpl.java
+++ b/src/main/java/edu/kh/laf/product/model/service/CartServiceImpl.java
@@ -63,6 +63,13 @@ public class CartServiceImpl implements CartService {
 		return mapper.insertCart(cartList);
 	}
 	
+	// [회원] 장바구니에 상품 추가2
+	@Override
+	@Transactional(rollbackFor = Exception.class)
+	public int insertCart(List<Cart> cartList) {
+		return mapper.insertCart(cartList);
+	}
+	
 	// [비회원] 장바구니에 상품 추가
 	@Override
 	public Cookie insertCart2(Cookie[] cookies, String data) {
@@ -257,6 +264,7 @@ public class CartServiceImpl implements CartService {
 			if(memberNo != -1) op.setMemberNo(memberNo);
 			op.setProductNo(Long.parseLong(map.get("productNo")));
 			op.setOptionNo(Long.parseLong(map.get("optionNo")));
+			op.setCount(Integer.parseInt(map.get("count")));
 			orderProductList.add(op);
 		}
 	

--- a/src/main/java/edu/kh/laf/product/model/service/OptionService.java
+++ b/src/main/java/edu/kh/laf/product/model/service/OptionService.java
@@ -55,5 +55,12 @@ public interface OptionService {
 	 * @return resultMap
 	 */
 	public Map<String, Object> selectOptionListBySeveralKeys(Map<String, Object> paramMap);
+
+	/**
+	 * 옵션 번호로 재고량 조회
+	 * @param optionNo
+	 * @return stock
+	 */
+	int selectStock(long optionNo);
 	
 }

--- a/src/main/java/edu/kh/laf/product/model/service/OptionServiceImpl.java
+++ b/src/main/java/edu/kh/laf/product/model/service/OptionServiceImpl.java
@@ -100,4 +100,10 @@ public class OptionServiceImpl implements OptionService {
 		return resultMap;
 	}
 
+	// 옵션 번호로 재고량 조회
+	@Override
+	public int selectStock(long optionNo) {
+		return mapper.selectStock(optionNo);
+	}
+
 }

--- a/src/main/resources/mappers/option-mapper.xml
+++ b/src/main/resources/mappers/option-mapper.xml
@@ -46,5 +46,12 @@
 		WHERE 	option_no = ${optionNo}
 	</select>
 	
+	<!-- 옵션 번호로 재고량 조회 -->
+	<select id="selectStock" resultType="int">
+		select stock
+		from `option`
+		where option_no = ${optionNo}
+	</select>
+	
 </mapper>
 

--- a/src/main/resources/static/css/common/default.css
+++ b/src/main/resources/static/css/common/default.css
@@ -193,6 +193,7 @@ button {
 }
 button:disabled {
   color: #eee;
+  cursor: default;
 }
 button:hover:not(:disabled) {
   background-color: #eee;

--- a/src/main/resources/static/css/shopping/cart.css
+++ b/src/main/resources/static/css/shopping/cart.css
@@ -23,6 +23,7 @@ table tr:last-child {
 }
 table td {
   padding: 3px 0;
+  min-height: 34px;;
   
   display: inline-flex;
   align-items: center;
@@ -30,6 +31,9 @@ table td {
 }
 table tr:not(:first-child) > td {
   height: 100px;
+}
+input[name='checkbox']:disabled {
+  cursor: default;
 }
 
 /* 버튼 컨테이너 공통설정 */
@@ -85,15 +89,44 @@ tr:not(:first-child) > .cart-item-product {
   color: #666;
   text-decoration: line-through;
 }
+.cart-item-count {
+  position: relative;
+}
 #cartItemList .cart-item-count button {
   width: 20px;
   height: 20px;
   /* margin: 0 10px; */
 }
-.cart-item-count > span {
+.count {
   /* 주문수량 출력부 */
+  /* display: inline-block; */
   text-align: center;
   width: 40px;  
+}
+.out-of-stock {
+  color: #D66600;
+}
+#emptyStockRemoveBtn span {
+  color: #D66600;
+  font-size: inherit;
+}
+.option-change-btn:disabled {
+  cursor: default;
+}
+.cart-item-count {
+  display: inline-flex;
+  /* flex-direction: column; */
+}
+.out-of-stock-2 {
+  color: #D66600;
+}
+.out-of-stock-3 {
+  color: #D66600;
+  font-size: 1.1rem;
+  margin-top: 3px;
+  position: absolute;
+  bottom: 20px;
+  margin: 0 auto;
 }
 
 /* 결제예상금액 */

--- a/src/main/resources/static/js/shopping/product.js
+++ b/src/main/resources/static/js/shopping/product.js
@@ -125,14 +125,15 @@ for(let btn of eventBtns) {
     minusBtn.setAttribute("type", "button");
     minusBtn.classList.add("count-down");
     minusBtn.innerText = "-";
+    minusBtn.disabled = true;
     minusBtn.addEventListener('click', e => {
       const curCount = e.target.parentElement.querySelector('span');
       const newCount = Number(curCount.innerText) - 1;
       curCount.innerText = newCount;
       
-      if(curCount.innerText == '0') {
-        alert('최소 주문 수량은 1개 입니다.');
-        curCount.innerText = 1;
+      e.target.parentElement.querySelector('.count-up').disabled = false;
+      if(curCount.innerText == '1') {
+        e.target.disabled = true;
       }
 
       const selectPrice = e.target.parentElement.parentElement.querySelector('.current-price');
@@ -150,20 +151,17 @@ for(let btn of eventBtns) {
     plusBtn.innerText = "+";
     plusBtn.addEventListener('click', e => {
       const curCount = e.target.parentElement.querySelector('span');
-      const newCount = Number(curCount.innerText) + 1;
+      let newCount = Number(curCount.innerText) + 1;
       curCount.innerText = newCount;
-      if(curCount.innerText == '100') {
-        alert('최대 주문 수량은 99개 입니다.');
-        curCount.innerText = 99;
+      if(curCount.innerText == '99') {
+        e.target.disabled = true;
       }
 
+      e.target.parentElement.querySelector('.count-down').disabled = false;
       for(let s of stocks) {
-        if(s.optionNo == optionNo) {
-          if(curCount.innerText > s.stock) {
-            alert('재고량을 초과했습니다. 현재 최대 주문 수량은 ' + s.stock + '개 입니다.');
-            curCount.innerText = s.stock;
+        if(s.optionNo == optionNo && curCount.innerText == s.stock) {
+            e.target.disabled = true;
           }
-        }
       }
 
       const selectPrice = e.target.parentElement.parentElement.querySelector('.current-price');
@@ -263,11 +261,11 @@ addCartBtn.addEventListener('click', () => {
     fetch("/cart/add2?data=" + cookieStr)
     .then(resp => resp.text())
     .then(result => {
-      if(result > 0) {
+      if(result == "성공") {
         if(flag) alert("중복된 상품을 제외하고 장바구니에 추가하였습니다.");
         else alert("선택한 상품을 장바구니에 담았습니다.");
       } else {
-        alert("장바구니 담기 실패");
+        alert(result);
       }
     }) 
     .catch(err => console.log(err));
@@ -285,42 +283,13 @@ addCartBtn.addEventListener('click', () => {
         "count": item.querySelector('.current-count span').innerText
       });
     }
-    
-    // 장바구니 데이터 가져와서 중복 있는지 확인
-    let flag = false;
-    fetch("/cart/list")
-    .then(resp => resp.json())
-    .then(cartList => {
 
-      for(let cart of cartList) {
-        for(let i=0; i<data.length; i++) {
-          // 장바구니에 이미 담긴 상품일 경우 제외
-          if(data[i].optionNo == cart.optionNo) {
-            data.splice(i, 1);
-            flag = true;
-          }
-        }
-      }
-
-      // 장바구니에 새로 추가할 상품이 없는 경우 함수 종료
-      if(data.length <= 0 && flag) {
-        alert("이미 추가된 상품입니다. 새로 추가할 상품이 없습니다.");
-        return;
-      }
-      
-      // 장바구니 정보 DB에 저장 
-      const dataStr = encodeURIComponent(JSON.stringify(data));
-      fetch("/cart/add?data=" + dataStr)
-      .then(resp => resp.text())
-      .then(result => {
-        if(result > 0) {
-          if(flag) alert("중복된 상품을 제외하고 장바구니에 추가하였습니다.");
-          else alert("선택한 상품을 장바구니에 담았습니다.");
-        } else {
-          alert("장바구니 담기 실패")
-        }
-      }) 
-      .catch(err => console.log(err));
+    // 장바구니 정보 DB에 저장 
+    const dataStr = encodeURIComponent(JSON.stringify(data));
+    fetch("/cart/add?data=" + dataStr)
+    .then(resp => resp.text())
+    .then(result => {
+      alert(result);
     }) 
     .catch(err => console.log(err));
   }

--- a/src/main/resources/templates/shopping/cart.html
+++ b/src/main/resources/templates/shopping/cart.html
@@ -45,7 +45,8 @@
             <input type="hidden" name="count" th:value="${cartList[productStat.index].count}">
             
             <td class="cart-item-checkbox">
-              <input type="checkbox" name="checkbox" class="checkbox-item">
+              <input th:if="${optionList[productStat.index].stock > 0}" type="checkbox" name="checkbox" class="checkbox-item">
+              <input th:unless="${optionList[productStat.index].stock > 0}" type="checkbox" name="checkbox" class="checkbox-item" disabled>
             </td>
             
             <td class="cart-item-image">
@@ -58,7 +59,8 @@
               <a th:href="@{/product/{productNo}(productNo = ${product.productNo})}" 
                 th:text="${product.productName}">상품명</a>
               <p class="cart-item-product-option">
-                <button class="option-change-btn" type="button">옵션변경</button>
+                <button class="option-change-btn" type="button" th:if="${optionList[productStat.index].stock > 0}">옵션변경</button>
+                <button class="option-change-btn" type="button" th:unless="${optionList[productStat.index].stock > 0}" disabled>옵션변경</button>
 
                 <!-- 사이즈가 있는 상품 -->
                 <span class="cart-item-selected-option" 
@@ -72,10 +74,28 @@
               </p>
             </td>
             
-            <td class="cart-item-count">
-              <button type="button" class="minus-btn">-</button>
-              <span th:text="${cartList[productStat.index].count}">주문수량</span>
-              <button type="button" class="plus-btn">+</button>
+            <!-- 정상 상태 -->
+            <td class="cart-item-count" th:if="${optionList[productStat.index].stock > 0} and ${optionList[productStat.index].stock >= cartList[productStat.index].count}">
+              <!-- <div class="count-btn-container"> -->
+                <button type="button" class="minus-btn">-</button>
+                <span class="count" th:text="${cartList[productStat.index].count}" th:max="${optionList[productStat.index].stock}">주문수량</span>
+                <button type="button" class="plus-btn">+</button>
+              <!-- </div> -->
+            </td>
+
+            <!-- 재고 부족 상태 -->
+            <td class="cart-item-count" th:if="${optionList[productStat.index].stock > 0} and ${optionList[productStat.index].stock lt cartList[productStat.index].count}">
+              <!-- <div class="count-btn-container"> -->
+                <button type="button" class="minus-btn">-</button>
+                <span th:text="${cartList[productStat.index].count}" th:max="${optionList[productStat.index].stock}" class="count out-of-stock-2">주문수량</span>
+                <button type="button" class="plus-btn">+</button>
+              <!-- </div> -->
+              <span class="out-of-stock-3">재고부족</span>
+            </td>
+
+            <!-- 품절 상태 -->
+            <td class="cart-item-count" th:unless="${optionList[productStat.index].stock > 0}">
+              <span class="out-of-stock">품절</span>
             </td>
             
             <td class="cart-item-price-set">
@@ -96,6 +116,7 @@
         </table>
 
         <div class="btn-container">
+          <button type="button" id="emptyStockRemoveBtn"><span>품절</span>상품 일괄삭제</button>
           <button type="button" id="deleteSelectedBtn">선택상품삭제</button>
           <button type="button" id="clearCartBtn">장바구니비우기</button>
         </div>


### PR DESCRIPTION
### **재고량 체크 기능 추가**
1. 재고 확인 후 재고가 부족할 경우 안내문구 출력
    - 상품 상세 화면에서 수량 추가 시
    - 장바구니에 담을 때
    - 장바구니에서 수량 수정 시
    - 주문 전송 시
2. 장바구니에 담아두었던 상품이 품절되었을 경우 품절 표시
3. 장바구니에 담아두었던 상품의 재고가 부족해졌을 경우 재고부족 표시
3. 장바구니 내 품절상품 일괄삭제 기능 추가
4. 0개 이하, 재고량 초과하는 갯수 선택 시 (기존) 경고창 출력 → (수정) 버튼 비활성화
5. 색상/사이즈 옵션 변경 시 선택 수량 1로 초기화


### **기타 업데이트 사항**
- default.css 수정 : 버튼 비활성화 시 cursor: pointer 해제
- 관리자페이지 접근제한 필터 일시 해지


### **오류수정**
- 항상 전체 상품이 검색되던 오류 수정
- 재고가 부족할 때 수량은 그대로인데 가격은 추가되는 오류 수정
- 상품 상세 화면에서 바로주문 클릭 시 주문수량이 넘어가지 않는 오류 수정